### PR TITLE
Add webhook-compatible HTTP API (closes #9)

### DIFF
--- a/docs/WEBHOOK-API.md
+++ b/docs/WEBHOOK-API.md
@@ -1,0 +1,193 @@
+# TafsirBot Webhook API
+
+Thin HTTP API wrapping the existing `rag_poc` RAG pipeline. Designed to be
+structurally close to the intended n8n webhook model so the interface can be
+adopted by channel-specific n8n workflows with no changes.
+
+---
+
+## Setup
+
+```bash
+# 1. Install dependencies (adds fastapi + uvicorn)
+uv sync
+
+# 2. Copy and fill in your .env
+cp .env.example .env
+# Required: OPENAI_API_KEY, ANTHROPIC_API_KEY (if using Anthropic provider)
+# Required: Qdrant running — docker compose up -d qdrant
+
+# 3. Start the API server
+uv run uvicorn scripts.api:app --host 0.0.0.0 --port 8000
+
+# Development (auto-reload on file changes)
+uv run uvicorn scripts.api:app --host 0.0.0.0 --port 8000 --reload
+```
+
+The server initialises the sparse embedding model, Qdrant client, and LLM
+clients on startup. First startup may take a few seconds if the BM42 model
+cache is cold (~130 MB download).
+
+> **Git worktree note:** If running from a worktree that does not have the
+> `sources/quran-json/dist/` directory, set `QURAN_JSON_DIST` to an absolute
+> path in your `.env`:
+> ```
+> QURAN_JSON_DIST=/absolute/path/to/TafsirBot/sources/quran-json/dist
+> ```
+
+---
+
+## Endpoints
+
+### `GET /health`
+
+Liveness check. Returns available LLM providers.
+
+```bash
+curl http://localhost:8000/health
+```
+
+```json
+{
+  "status": "ok",
+  "version": "0.1.0",
+  "providers": ["openai", "anthropic"]
+}
+```
+
+---
+
+### `POST /query`
+
+Run the full RAG pipeline for a user message.
+
+**Request body:**
+
+```json
+{
+  "channel": "web",
+  "session_id": "local-session-id",
+  "user_id": "local-user",
+  "message": "What does Ibn Kathir say about Ayat al-Kursi?",
+  "conversation_history": [
+    {"role": "user", "content": "Tell me about Surah Al-Baqarah."},
+    {"role": "assistant", "content": "..."}
+  ],
+  "options": {
+    "provider": "anthropic",
+    "scholar": null,
+    "top_k": 5,
+    "save": true
+  }
+}
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `channel` | string | `"web"` | Channel identifier (informational; included in `meta`) |
+| `session_id` | string | `"local-session"` | Session identifier echoed back in the response |
+| `user_id` | string | `"local-user"` | User identifier (informational) |
+| `message` | string | required | The raw user query |
+| `conversation_history` | array | `[]` | Prior turns; last 3 pairs (6 messages) are included in the LLM call |
+| `options.provider` | `"anthropic"` \| `"openai"` | `LLM_PROVIDER` env | LLM provider for intent classification and generation |
+| `options.scholar` | string \| null | `null` | Restrict retrieval to a scholar slug (e.g. `"ibn_kathir"`) |
+| `options.top_k` | int 1–20 | `5` | Number of chunks to retrieve |
+| `options.save` | bool | `true` | Reserved for future Postgres session persistence |
+
+**Response body:**
+
+```json
+{
+  "request_id": "550e8400-e29b-41d4-a716-446655440000",
+  "session_id": "local-session-id",
+  "intent": "tafsir",
+  "normalized_message": "What does Ibn Kathir say about Ayat al-Kursi?",
+  "answer": "Ibn Kathir explains that Ayat al-Kursi (2:255)...\n\n**Sources:**\n- Ibn Kathir on 2:255...\n\n---\n*This response is an AI-assisted summary...*",
+  "citations": ["[Ibn Kathir on 2:255]"],
+  "confidence": "high",
+  "disclaimer_applied": true,
+  "fiqh_note_applied": false,
+  "chunks": [
+    {
+      "scholar": "ibn_kathir",
+      "surah_number": 2,
+      "ayah_start": 255,
+      "ayah_end": 255,
+      "source_title": "Tafsir Ibn Kathir",
+      "score": 1.0,
+      "content_preview": "This is the greatest verse in the Quran..."
+    }
+  ],
+  "meta": {
+    "channel": "web",
+    "user_id": "local-user",
+    "provider": "anthropic",
+    "top_k": 5,
+    "scholar_filter": null,
+    "elapsed_ms": 2341
+  }
+}
+```
+
+**Intent behaviour:**
+
+| Intent | Behaviour |
+|---|---|
+| `tafsir` | Normal retrieval + generation + disclaimer |
+| `general_islamic` | Normal retrieval + generation + disclaimer |
+| `fiqh_ruling` | Retrieval + generation; `fiqh_note_applied: true`; answer prefixed with fiqh note |
+| `off_topic` | Polite refusal; no retrieval; `disclaimer_applied: false` |
+
+**curl example:**
+
+```bash
+curl -s -X POST http://localhost:8000/query \
+  -H "Content-Type: application/json" \
+  -d '{
+    "message": "Explain Quran 2:255",
+    "options": {"provider": "anthropic"}
+  }' | python3 -m json.tool
+```
+
+---
+
+## Interactive docs
+
+FastAPI auto-generates OpenAPI docs at:
+
+- Swagger UI: `http://localhost:8000/docs`
+- ReDoc: `http://localhost:8000/redoc`
+
+---
+
+## CLI (unchanged)
+
+The `rag_poc.py` CLI continues to work exactly as before:
+
+```bash
+uv run python scripts/rag_poc.py "What does Ibn Kathir say about 2:255?"
+uv run python scripts/rag_poc.py --scholar maududi "What is the theme of Surah Al-Baqarah?"
+uv run python scripts/rag_poc.py --provider openai --verbose "Explain tawakkul"
+```
+
+---
+
+## Assumptions and design notes
+
+- **Single-user / local use:** No authentication or rate-limiting is implemented.
+  Add an auth middleware before exposing to the internet.
+- **No Postgres persistence:** `options.save` is accepted but ignored. Conversation
+  history is stateless — callers must supply it with each request.
+- **Synchronous handlers:** Pipeline steps (embedding, LLM calls, Qdrant) are
+  blocking. For concurrent load, run with multiple uvicorn workers:
+  `uvicorn scripts.api:app --workers 4`.
+- **Conversation history:** The last 6 messages (3 turn-pairs) from
+  `conversation_history` are included in the LLM generation call. Intent
+  classification always uses only the current message.
+- **Provider per request:** The `options.provider` field controls which LLM is
+  used for both intent classification and generation. Both providers are
+  initialised at startup if their API keys are present; a missing key causes a
+  422 error if that provider is requested.
+- **`chunks` in response:** Retrieved chunk summaries (first 200 chars) are
+  included for UI rendering and debugging. Strip this field if response size
+  is a concern.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ dependencies = [
     "requests>=2.32.0",
     "beautifulsoup4>=4.12.0",
     "fastembed>=0.4.0",
+    "fastapi>=0.111.0",
+    "uvicorn>=0.30.0",
 ]
 
 [dependency-groups]

--- a/scripts/api.py
+++ b/scripts/api.py
@@ -1,0 +1,229 @@
+"""
+api.py — Thin webhook-compatible HTTP API for TafsirBot.
+
+Wraps the rag_poc pipeline in a FastAPI app.  All expensive resources
+(LLM clients, sparse embedding model, Qdrant connection, AyahResolver)
+are initialised once at startup via rag_poc.build_runtime() and reused
+across requests.
+
+Run:
+    uv run uvicorn scripts.api:app --host 0.0.0.0 --port 8000
+    uv run uvicorn scripts.api:app --host 0.0.0.0 --port 8000 --reload  # dev
+
+From inside the scripts/ directory:
+    cd scripts && uv run uvicorn api:app --port 8000
+
+See docs/WEBHOOK-API.md for endpoint documentation and curl examples.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import time
+import uuid
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Literal
+
+# Allow imports from scripts/ingestion/utils/ and from rag_poc (same directory)
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent / "ingestion"))
+
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parents[1] / ".env")
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+import rag_poc
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s — %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger("tafsirbot.api")
+
+
+# ── Pydantic request / response models ────────────────────────────────────────
+
+
+class QueryOptions(BaseModel):
+    provider: Literal["anthropic", "openai"] = Field(
+        default_factory=lambda: os.environ.get("LLM_PROVIDER", "anthropic")
+    )
+    scholar: str | None = None
+    top_k: int = Field(default=rag_poc.TOP_K, ge=1, le=20)
+    save: bool = True  # reserved for future Postgres persistence
+
+
+class ConversationTurn(BaseModel):
+    role: Literal["user", "assistant"]
+    content: str
+
+
+class QueryRequest(BaseModel):
+    channel: str = "web"
+    session_id: str = "local-session"
+    user_id: str = "local-user"
+    message: str
+    conversation_history: list[ConversationTurn] = Field(default_factory=list)
+    options: QueryOptions = Field(default_factory=QueryOptions)
+
+
+class ChunkSummary(BaseModel):
+    scholar: str
+    surah_number: int | None
+    ayah_start: int | None
+    ayah_end: int | None
+    source_title: str
+    score: float
+    content_preview: str  # first 200 chars of chunk content
+
+
+class QueryResponse(BaseModel):
+    request_id: str
+    session_id: str
+    intent: str
+    normalized_message: str
+    answer: str
+    citations: list[str]
+    confidence: str
+    disclaimer_applied: bool
+    fiqh_note_applied: bool
+    chunks: list[ChunkSummary]
+    meta: dict
+
+
+class HealthResponse(BaseModel):
+    status: str
+    version: str = "0.1.0"
+    providers: list[str]
+
+
+# ── App lifespan (startup / shutdown) ────────────────────────────────────────
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    logger.info("Initialising TafsirBot runtime…")
+    runtime = rag_poc.build_runtime()
+    app.state.runtime = runtime
+    logger.info("Runtime ready — providers: %s", list(runtime["clients"].keys()))
+    yield
+    logger.info("Shutting down.")
+
+
+app = FastAPI(
+    title="TafsirBot Webhook API",
+    description=(
+        "Webhook-compatible HTTP API wrapping the TafsirBot RAG pipeline. "
+        "Accepts queries in a channel-agnostic envelope and returns structured JSON "
+        "including the generated answer, citations, retrieved chunks, and metadata."
+    ),
+    version="0.1.0",
+    lifespan=lifespan,
+)
+
+
+# ── Endpoints ─────────────────────────────────────────────────────────────────
+
+
+@app.get("/health", response_model=HealthResponse, tags=["ops"])
+def health() -> HealthResponse:
+    """Liveness check. Returns available LLM providers."""
+    runtime = app.state.runtime
+    return HealthResponse(
+        status="ok",
+        providers=list(runtime["clients"].keys()),
+    )
+
+
+@app.post("/query", response_model=QueryResponse, tags=["rag"])
+def query(req: QueryRequest) -> QueryResponse:
+    """
+    Run the full RAG pipeline for a single user message.
+
+    - `off_topic` intent: returns a polite refusal with no retrieval.
+    - `fiqh_ruling` intent: retrieves and responds with scholarly context;
+      prepends a note that the response is not a personal fatwa.
+    - All other intents: normal retrieval + generation + disclaimer.
+    """
+    runtime = app.state.runtime
+    provider = req.options.provider
+
+    if provider not in runtime["clients"]:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Provider {provider!r} is not configured — "
+                "add the corresponding API key to .env."
+            ),
+        )
+
+    conversation_history = [t.model_dump() for t in req.conversation_history] or None
+
+    t0 = time.monotonic()
+    try:
+        result: rag_poc.PipelineResult = rag_poc.run_pipeline(
+            req.message,
+            provider=provider,
+            scholar=req.options.scholar,
+            top_k=req.options.top_k,
+            conversation_history=conversation_history,
+            clients=runtime["clients"],
+            qdrant_client=runtime["qdrant_client"],
+            collection=runtime["collection"],
+            resolver=runtime["resolver"],
+            sparse_model=runtime["sparse_model"],
+        )
+    except Exception as exc:
+        # Surface API provider errors (billing, auth, quota) as 502 so callers
+        # get a structured error instead of a plain-text 500 page.
+        msg = str(exc)
+        status = 502
+        # Detect common upstream error patterns
+        if any(k in msg for k in ("credit balance", "insufficient", "quota", "rate limit")):
+            status = 429
+        elif any(k in msg for k in ("authentication", "api key", "unauthorized")):
+            status = 401
+        logger.error("Pipeline error (%s %s): %s", provider, req.message[:60], msg)
+        raise HTTPException(status_code=status, detail=msg) from exc
+    elapsed_ms = round((time.monotonic() - t0) * 1000)
+
+    chunk_summaries = [
+        ChunkSummary(
+            scholar=c["scholar"],
+            surah_number=c.get("surah_number"),
+            ayah_start=c.get("ayah_start"),
+            ayah_end=c.get("ayah_end"),
+            source_title=c.get("source_title", ""),
+            score=round(c["score"], 4),
+            content_preview=c["content"][:200],
+        )
+        for c in result.chunks
+    ]
+
+    return QueryResponse(
+        request_id=str(uuid.uuid4()),
+        session_id=req.session_id,
+        intent=result.intent,
+        normalized_message=result.normalized_message,
+        answer=result.answer,
+        citations=result.citations,
+        confidence=result.confidence,
+        disclaimer_applied=result.disclaimer_applied,
+        fiqh_note_applied=result.fiqh_note_applied,
+        chunks=chunk_summaries,
+        meta={
+            "channel": req.channel,
+            "user_id": req.user_id,
+            "provider": provider,
+            "top_k": req.options.top_k,
+            "scholar_filter": req.options.scholar,
+            "elapsed_ms": elapsed_ms,
+        },
+    )

--- a/scripts/rag_poc.py
+++ b/scripts/rag_poc.py
@@ -20,7 +20,6 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import json
 import logging
 import os
 import re
@@ -73,6 +72,7 @@ TEMPERATURE = 0.3
 
 CLAUDE_MODEL = "claude-sonnet-4-6"
 OPENAI_MODEL = "gpt-4o"
+SPARSE_MODEL_NAME = "Qdrant/bm42-all-minilm-l6-v2-attentions"
 
 
 # ── Step 1: Normalize input ───────────────────────────────────────────────────
@@ -276,29 +276,40 @@ def assemble_prompt(query: str, chunks: list[dict]) -> str:
 
 # ── Step 6: LLM generation ────────────────────────────────────────────────────
 
-def generate(prompt: str, provider: Provider, clients: dict, verbose: bool) -> str:
+def generate(
+    prompt: str,
+    provider: Provider,
+    clients: dict,
+    verbose: bool,
+    *,
+    conversation_history: list[dict] | None = None,
+) -> str:
     if verbose:
         logger.setLevel(logging.DEBUG)
         logger.debug("Prompt length: %d chars", len(prompt))
 
+    # Include at most the last 3 turn-pairs (6 messages) for context.
+    history = list(conversation_history[-6:]) if conversation_history else []
+
     if provider == "anthropic":
+        messages = history + [{"role": "user", "content": prompt}]
         msg = clients["anthropic"].messages.create(
             model=CLAUDE_MODEL,
             max_tokens=MAX_TOKENS,
             temperature=TEMPERATURE,
             system=SYSTEM_PROMPT,
-            messages=[{"role": "user", "content": prompt}],
+            messages=messages,
         )
         return msg.content[0].text.strip()
     else:
+        chat_messages: list[dict] = [{"role": "system", "content": SYSTEM_PROMPT}]
+        chat_messages.extend(history)
+        chat_messages.append({"role": "user", "content": prompt})
         resp = clients["openai"].chat.completions.create(
             model=OPENAI_MODEL,
             max_tokens=MAX_TOKENS,
             temperature=TEMPERATURE,
-            messages=[
-                {"role": "system", "content": SYSTEM_PROMPT},
-                {"role": "user", "content": prompt},
-            ],
+            messages=chat_messages,
         )
         return resp.choices[0].message.content.strip()
 
@@ -368,6 +379,150 @@ def post_process(
     )
 
 
+# ── Public pipeline interface ─────────────────────────────────────────────────
+
+
+@dataclass
+class PipelineResult:
+    """Structured result from run_pipeline(), suitable for API and programmatic use."""
+
+    intent: str
+    normalized_message: str
+    answer: str                      # final answer with sources + disclaimer
+    citations: list[str]             # inline [Scholar on S:V] markers
+    confidence: Literal["high", "low"]
+    disclaimer_applied: bool
+    fiqh_note_applied: bool
+    chunks: list[dict]               # raw retrieved chunks (for debugging / UI)
+
+
+def build_runtime() -> dict:
+    """
+    Initialise all expensive resources once: LLM clients, Qdrant connection,
+    AyahResolver, and the sparse embedding model.
+
+    Always loads OpenAI (required for embeddings).  Loads Anthropic only when
+    ANTHROPIC_API_KEY is present.  Raises RuntimeError if OPENAI_API_KEY is
+    missing.
+
+    Returns a dict with keys:
+        clients, qdrant_client, collection, resolver, sparse_model
+    """
+    from fastembed import SparseTextEmbedding
+    from qdrant_client import QdrantClient
+    from utils.quran_ref import QuranRef
+    from utils.ayah_resolver import AyahResolver
+
+    openai_key = os.environ.get("OPENAI_API_KEY")
+    if not openai_key:
+        raise RuntimeError("OPENAI_API_KEY is required (used for dense embeddings).")
+
+    import openai as _openai
+
+    clients: dict = {}
+    clients["openai"] = _openai.OpenAI(api_key=openai_key)
+
+    anthropic_key = os.environ.get("ANTHROPIC_API_KEY")
+    if anthropic_key:
+        import anthropic as _anthropic
+
+        clients["anthropic"] = _anthropic.Anthropic(api_key=anthropic_key)
+
+    qdrant = QdrantClient(
+        host=os.environ.get("QDRANT_HOST", "localhost"),
+        port=int(os.environ.get("QDRANT_PORT", 6333)),
+    )
+    collection = os.environ.get("QDRANT_COLLECTION", "tafsir")
+    resolver = AyahResolver(QuranRef())
+    sparse_model = SparseTextEmbedding(SPARSE_MODEL_NAME)
+
+    return {
+        "clients": clients,
+        "qdrant_client": qdrant,
+        "collection": collection,
+        "resolver": resolver,
+        "sparse_model": sparse_model,
+    }
+
+
+def run_pipeline(
+    query: str,
+    *,
+    provider: Provider,
+    scholar: str | None = None,
+    top_k: int = TOP_K,
+    conversation_history: list[dict] | None = None,
+    clients: dict,
+    qdrant_client,
+    collection: str,
+    resolver,
+    sparse_model,
+) -> PipelineResult:
+    """
+    Run the full RAG pipeline end-to-end and return a structured PipelineResult.
+
+    All expensive resources must be pre-initialised (e.g. via build_runtime())
+    and passed in so they can be reused across multiple requests.
+    """
+    normalized = normalize(query)
+    intent = classify_intent(normalized, provider, clients)
+
+    if intent == "off_topic":
+        return PipelineResult(
+            intent=intent,
+            normalized_message=normalized,
+            answer=OFF_TOPIC_REFUSAL,
+            citations=[],
+            confidence="high",
+            disclaimer_applied=False,
+            fiqh_note_applied=False,
+            chunks=[],
+        )
+
+    refs = resolver.resolve(normalized)
+    scholar_filter = scholar if scholar and scholar.lower() != "all" else None
+    qdrant_filter = build_qdrant_filter(refs, scholar_filter)
+
+    dense_emb = embed_query_text(normalized, clients)
+    chunks = retrieve_chunks(
+        qdrant_client, collection, normalized, dense_emb, sparse_model, top_k, qdrant_filter
+    )
+
+    if not chunks:
+        return PipelineResult(
+            intent=intent,
+            normalized_message=normalized,
+            answer=f"No relevant Tafsir passages found for this query.{DISCLAIMER}",
+            citations=[],
+            confidence="low",
+            disclaimer_applied=True,
+            fiqh_note_applied=False,
+            chunks=[],
+        )
+
+    prompt = assemble_prompt(normalized, chunks)
+    raw_response = generate(
+        prompt, provider, clients, verbose=False,
+        conversation_history=conversation_history,
+    )
+    # threshold=0.0 because RRF scores are rank-based, not cosine distances
+    rag_result = post_process(raw_response, intent, chunks, threshold=0.0)
+
+    fiqh_applied = intent == "fiqh_ruling"
+    answer = FIQH_NOTE + rag_result.text if fiqh_applied else rag_result.text
+
+    return PipelineResult(
+        intent=intent,
+        normalized_message=normalized,
+        answer=answer,
+        citations=rag_result.citations,
+        confidence=rag_result.confidence,
+        disclaimer_applied=True,
+        fiqh_note_applied=fiqh_applied,
+        chunks=chunks,
+    )
+
+
 # ── Main ──────────────────────────────────────────────────────────────────────
 
 def main() -> None:
@@ -400,93 +555,47 @@ def main() -> None:
     if args.verbose:
         logging.getLogger().setLevel(logging.DEBUG)
 
-    # ── Build clients ─────────────────────────────────────────────────────────
-    from fastembed import SparseTextEmbedding
+    runtime = build_runtime()
 
-    clients: dict = {}
+    if args.provider not in runtime["clients"]:
+        print(
+            f"Error: provider {args.provider!r} is not configured — "
+            "add the corresponding API key to .env.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
-    if args.provider == "anthropic" or True:  # always need openai for embeddings
-        import openai as _openai
-        clients["openai"] = _openai.OpenAI(api_key=os.environ["OPENAI_API_KEY"])
-
-    if args.provider == "anthropic":
-        import anthropic as _anthropic
-        clients["anthropic"] = _anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
-
-    from qdrant_client import QdrantClient
-    qdrant = QdrantClient(
-        host=os.environ.get("QDRANT_HOST", "localhost"),
-        port=int(os.environ.get("QDRANT_PORT", 6333)),
-    )
-    collection = os.environ.get("QDRANT_COLLECTION", "tafsir")
-
-    from utils.quran_ref import QuranRef
-    from utils.ayah_resolver import AyahResolver
-
-    qr = QuranRef()
-    resolver = AyahResolver(qr)
-
-    sparse_model = SparseTextEmbedding("Qdrant/bm42-all-minilm-l6-v2-attentions")
-
-    # ── Pipeline ──────────────────────────────────────────────────────────────
     print()
 
-    # Step 1: Normalize
-    query = normalize(args.query)
+    result = run_pipeline(
+        args.query,
+        provider=args.provider,
+        scholar=args.scholar,
+        top_k=args.top_k,
+        clients=runtime["clients"],
+        qdrant_client=runtime["qdrant_client"],
+        collection=runtime["collection"],
+        resolver=runtime["resolver"],
+        sparse_model=runtime["sparse_model"],
+    )
 
-    # Step 2: Classify intent
-    intent = classify_intent(query, args.provider, clients)
-
-    if intent == "off_topic":
-        print(OFF_TOPIC_REFUSAL)
-        return
-
-    # fiqh_ruling: do not refuse — retrieve and respond with scholarly context,
-    # but prepend FIQH_NOTE so the user knows it is not a personal ruling.
-
-    # Step 3: Resolve Ayah references
-    refs = resolver.resolve(query)
-    if args.verbose and refs:
-        print(f"[refs] {refs}\n")
-
-    scholar_filter = args.scholar if args.scholar and args.scholar.lower() != "all" else None
-    qdrant_filter = build_qdrant_filter(refs, scholar_filter)
-
-    # Step 4: Embed + retrieve
-    dense_emb = embed_query_text(query, clients)
-    chunks = retrieve_chunks(qdrant, collection, query, dense_emb, sparse_model, args.top_k, qdrant_filter)
-
-    if args.verbose:
-        print(f"[retrieved {len(chunks)} chunks]")
-        for c in chunks:
+    if args.verbose and result.chunks:
+        print(f"[refs resolved; retrieved {len(result.chunks)} chunks]")
+        for c in result.chunks:
             print(
                 f"  [{c['scholar']}] {c['surah_number']}:{c['ayah_start']} "
                 f"score={c['score']:.3f} — {c['content'][:80]}..."
             )
         print()
 
-    if not chunks:
-        print("No relevant Tafsir passages found for this query.")
-        print(DISCLAIMER)
-        return
-
-    # Step 5: Assemble prompt
-    prompt = assemble_prompt(query, chunks)
-
-    # Step 6: Generate
-    raw_response = generate(prompt, args.provider, clients, args.verbose)
-
-    # Step 7: Post-process (threshold=0 — RRF scores are rank-based, not cosine)
-    result = post_process(raw_response, intent, chunks, threshold=0.0)
-
-    output = result.text
-    if intent == "fiqh_ruling":
-        output = FIQH_NOTE + output
-    print(output)
+    print(result.answer)
 
     if args.verbose:
         print(f"\n[citations: {result.citations}]")
-        print(f"[confidence: {result.confidence}  chunks: {result.chunks_used}  intent: {result.intent}]")
+        print(
+            f"[confidence: {result.confidence}  chunks: {len(result.chunks)}"
+            f"  intent: {result.intent}]"
+        )
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -193,6 +193,22 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.135.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/7b/f8e0211e9380f7195ba3f3d40c292594fd81ba8ec4629e3854c353aaca45/fastapi-0.135.1.tar.gz", hash = "sha256:d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd", size = 394962, upload-time = "2026-03-01T18:18:29.369Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/72/42e900510195b23a56bde950d26a51f8b723846bfcaa0286e90287f0422b/fastapi-0.135.1-py3-none-any.whl", hash = "sha256:46e2fc5745924b7c840f71ddd277382af29ce1cdb7d5eab5bf697e3fb9999c9e", size = 116999, upload-time = "2026-03-01T18:18:30.831Z" },
+]
+
+[[package]]
 name = "fastembed"
 version = "0.7.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1358,6 +1374,19 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette"
+version = "0.52.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+]
+
+[[package]]
 name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1376,6 +1405,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },
     { name = "beautifulsoup4" },
+    { name = "fastapi" },
     { name = "fastembed" },
     { name = "openai" },
     { name = "python-dotenv" },
@@ -1383,6 +1413,7 @@ dependencies = [
     { name = "requests" },
     { name = "tiktoken" },
     { name = "tqdm" },
+    { name = "uvicorn" },
 ]
 
 [package.dev-dependencies]
@@ -1394,6 +1425,7 @@ dev = [
 requires-dist = [
     { name = "anthropic", specifier = ">=0.28.0" },
     { name = "beautifulsoup4", specifier = ">=4.12.0" },
+    { name = "fastapi", specifier = ">=0.111.0" },
     { name = "fastembed", specifier = ">=0.4.0" },
     { name = "openai", specifier = ">=1.30.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
@@ -1401,6 +1433,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.0" },
     { name = "tiktoken", specifier = ">=0.7.0" },
     { name = "tqdm", specifier = ">=4.66.0" },
+    { name = "uvicorn", specifier = ">=0.30.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1541,6 +1574,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Refactored `scripts/rag_poc.py`** to expose a callable pipeline interface — `build_runtime()`, `run_pipeline()`, and `PipelineResult` — so the RAG pipeline can be driven from application code, not only the CLI. `RAGResponse`/`post_process()` kept intact; `test_poc.py` unaffected.
- **New `scripts/api.py`** — thin FastAPI app wrapping the pipeline:
  - `GET /health` — liveness check, returns configured providers
  - `POST /query` — channel-agnostic envelope (channel, session_id, user_id, message, conversation_history, options) → structured JSON response with request_id, intent, answer, citations, confidence, disclaimer flags, chunk summaries, and meta
  - Provider billing/auth errors surfaced as 429/401/502 instead of plain 500
  - All guardrails (off_topic refusal, fiqh_ruling note, disclaimer) preserved
- **`pyproject.toml`** — added `fastapi>=0.111.0` and `uvicorn>=0.30.0`
- **`docs/WEBHOOK-API.md`** — run instructions, endpoint reference, curl examples, design notes

## Test plan

- [x] `GET /health` returns `{"status":"ok","providers":[...]}`
- [x] `POST /query` with `tafsir` intent returns citations, sources, disclaimer
- [x] `POST /query` with `fiqh_ruling` intent prepends fiqh note, sets `fiqh_note_applied: true`
- [x] `POST /query` with `off_topic` intent returns polite refusal, no chunks, no disclaimer
- [x] Anthropic out-of-credits error returns HTTP 429 with structured detail
- [x] `scholar` filter and `top_k` options applied correctly
- [x] CLI (`uv run python scripts/rag_poc.py ...`) unchanged
- [x] `test_poc.py` imports unaffected (RAGResponse, post_process, SPARSE_MODEL_NAME all still present)

## Assumptions / deferred

- No Postgres persistence — `options.save` accepted but ignored
- No auth — single-user local use as scoped in issue
- Synchronous handlers — scale with `uvicorn --workers N` if needed
- Conversation history is stateless — callers supply it each request

🤖 Generated with [Claude Code](https://claude.com/claude-code)