### PR TITLE
API: hadith collection architecture stub

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,8 @@ EMBEDDING_MODEL=text-embedding-3-large
 QDRANT_HOST=localhost
 QDRANT_PORT=6333
 QDRANT_COLLECTION=tafsir
+# Separate collection for Hadith corpus (Phase 3+). Set when hadith data is ingested.
+QDRANT_HADITH_COLLECTION=hadith
 
 # ── Postgres ──────────────────────────────────────────────────────────────────
 # Docker container init settings and local app connection settings.

--- a/scripts/api.py
+++ b/scripts/api.py
@@ -57,6 +57,8 @@ class QueryOptions(BaseModel):
         default_factory=lambda: os.environ.get("LLM_PROVIDER", "anthropic")
     )
     scholars: list[str] | None = None
+    hadith_enabled: bool = False
+    hadith_collections: list[str] | None = None
     top_k: int = Field(default=rag_poc.TOP_K, ge=1, le=20)
     save: bool = True
 
@@ -252,6 +254,8 @@ def _save_chat_exchange(
         metadata={
             "provider": req.options.provider,
             "scholars": req.options.scholars,
+            "hadith_enabled": req.options.hadith_enabled,
+            "hadith_collections": req.options.hadith_collections,
             "top_k": req.options.top_k,
         },
     )
@@ -301,6 +305,9 @@ def _build_query_response(req: QueryRequest) -> QueryResponse:
             req.message,
             provider=provider,
             scholars=req.options.scholars,
+            hadith_enabled=req.options.hadith_enabled,
+            hadith_collection=runtime["hadith_collection"],
+            hadith_collections=req.options.hadith_collections,
             top_k=req.options.top_k,
             conversation_history=conversation_history,
             clients=runtime["clients"],
@@ -353,6 +360,8 @@ def _build_query_response(req: QueryRequest) -> QueryResponse:
             "provider": provider,
             "top_k": req.options.top_k,
             "scholars": req.options.scholars or None,
+            "hadith_enabled": req.options.hadith_enabled,
+            "hadith_collections": req.options.hadith_collections or None,
             "elapsed_ms": elapsed_ms,
         },
     )

--- a/scripts/rag_poc.py
+++ b/scripts/rag_poc.py
@@ -149,7 +149,7 @@ def classify_intent(query: str, provider: Provider, clients: dict) -> Intent:
     return intent  # type: ignore[return-value]
 
 
-# ── Step 3: Ayah reference resolution ────────────────────────────────────────
+# ── Step 3: Ayah reference resolution + filters ───────────────────────────────
 
 def build_qdrant_filter(refs, scholars: list[str] | None) -> dict | None:
     """
@@ -181,6 +181,28 @@ def build_qdrant_filter(refs, scholars: list[str] | None) -> dict | None:
             conditions.append({"key": "ayah_end", "range": {"lte": ref.ayah_end}})
 
     return {"must": conditions} if conditions else None
+
+
+def build_hadith_filter(hadith_collections: list[str] | None) -> dict | None:
+    """
+    Build a Qdrant filter scoped to Hadith chunks.
+
+    Filters on the 'collection' payload field (e.g. 'bukhari', 'muslim').
+    - hadith_collections=None or []    → no filter (all hadith collections)
+    - hadith_collections=["bukhari"]   → single FieldCondition match
+    - hadith_collections=["bukhari", "muslim"] → nested should (OR)
+    """
+    if not hadith_collections:
+        return None
+    if len(hadith_collections) == 1:
+        return {"must": [{"key": "collection", "match": {"value": hadith_collections[0]}}]}
+    return {
+        "must": [{
+            "should": [
+                {"key": "collection", "match": {"value": c}} for c in hadith_collections
+            ]
+        }]
+    }
 
 
 # ── Step 4: Hybrid retrieval ──────────────────────────────────────────────────
@@ -418,7 +440,7 @@ def build_runtime() -> dict:
     missing.
 
     Returns a dict with keys:
-        clients, qdrant_client, collection, resolver, sparse_model
+        clients, qdrant_client, collection, hadith_collection, resolver, sparse_model
     """
     from fastembed import SparseTextEmbedding
     from qdrant_client import QdrantClient
@@ -445,6 +467,7 @@ def build_runtime() -> dict:
         port=int(os.environ.get("QDRANT_PORT", 6333)),
     )
     collection = os.environ.get("QDRANT_COLLECTION", "tafsir")
+    hadith_collection = os.environ.get("QDRANT_HADITH_COLLECTION", "hadith")
     resolver = AyahResolver(QuranRef())
     sparse_model = SparseTextEmbedding(SPARSE_MODEL_NAME)
 
@@ -452,6 +475,7 @@ def build_runtime() -> dict:
         "clients": clients,
         "qdrant_client": qdrant,
         "collection": collection,
+        "hadith_collection": hadith_collection,
         "resolver": resolver,
         "sparse_model": sparse_model,
     }
@@ -462,6 +486,9 @@ def run_pipeline(
     *,
     provider: Provider,
     scholars: list[str] | None = None,
+    hadith_enabled: bool = False,
+    hadith_collection: str | None = None,
+    hadith_collections: list[str] | None = None,
     top_k: int = TOP_K,
     conversation_history: list[dict] | None = None,
     clients: dict,
@@ -475,6 +502,11 @@ def run_pipeline(
 
     All expensive resources must be pre-initialised (e.g. via build_runtime())
     and passed in so they can be reused across multiple requests.
+
+    When hadith_enabled=True, the pipeline also queries the hadith Qdrant
+    collection and merges results with Tafsir chunks before generation.
+    If the hadith collection is missing or empty, a warning is logged and
+    the pipeline continues with Tafsir chunks only — no error is raised.
     """
     normalized = normalize(query)
     intent = classify_intent(normalized, provider, clients)
@@ -495,9 +527,31 @@ def run_pipeline(
     qdrant_filter = build_qdrant_filter(refs, scholars or None)
 
     dense_emb = embed_query_text(normalized, clients)
-    chunks = retrieve_chunks(
+    tafsir_chunks = retrieve_chunks(
         qdrant_client, collection, normalized, dense_emb, sparse_model, top_k, qdrant_filter
     )
+
+    # ── Optional Hadith retrieval ─────────────────────────────────────────────
+    hadith_chunks: list[dict] = []
+    if hadith_enabled and hadith_collection:
+        try:
+            h_filter = build_hadith_filter(hadith_collections or None)
+            raw_hadith = retrieve_chunks(
+                qdrant_client, hadith_collection, normalized, dense_emb,
+                sparse_model, top_k, h_filter,
+            )
+            # Normalise: use 'collection' payload field as 'scholar' so the
+            # rest of the pipeline (assemble_prompt, citations) works unchanged.
+            for chunk in raw_hadith:
+                if not chunk.get("scholar") or chunk["scholar"] == "unknown":
+                    chunk["scholar"] = chunk.get("collection", "hadith")
+            hadith_chunks = raw_hadith
+            logger.info("Hadith retrieval: %d chunks from %s", len(hadith_chunks), hadith_collection)
+        except Exception as exc:
+            logger.warning("Hadith retrieval skipped (%s): %s", hadith_collection, exc)
+
+    # Merge Tafsir + Hadith chunks; re-rank by score descending, keep top_k
+    chunks = sorted(tafsir_chunks + hadith_chunks, key=lambda c: c["score"], reverse=True)[:top_k]
 
     if not chunks:
         return PipelineResult(

--- a/tests/unit/test_rag_poc.py
+++ b/tests/unit/test_rag_poc.py
@@ -15,7 +15,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "ingestion"))
 
 import rag_poc
-from rag_poc import build_qdrant_filter
+from rag_poc import build_hadith_filter, build_qdrant_filter
 from utils.ayah_resolver import AyahRef
 
 
@@ -113,6 +113,43 @@ class TestBuildQdrantFilterWithRef:
         end_cond = next(c for c in result["must"] if c.get("key") == "ayah_end")
         assert start_cond["range"]["gte"] == 255
         assert end_cond["range"]["lte"] == 255
+
+
+# ── build_hadith_filter ───────────────────────────────────────────────────────
+
+
+class TestBuildHadithFilter:
+    def test_none_returns_none(self):
+        assert build_hadith_filter(None) is None
+
+    def test_empty_list_returns_none(self):
+        assert build_hadith_filter([]) is None
+
+    def test_single_collection(self):
+        result = build_hadith_filter(["bukhari"])
+        assert result == {
+            "must": [{"key": "collection", "match": {"value": "bukhari"}}]
+        }
+
+    def test_two_collections_produces_should(self):
+        result = build_hadith_filter(["bukhari", "muslim"])
+        assert result is not None
+        should_block = result["must"][0]
+        assert "should" in should_block
+        values = {c["match"]["value"] for c in should_block["should"]}
+        assert values == {"bukhari", "muslim"}
+
+    def test_all_six_kutub_al_sitta(self):
+        collections = ["bukhari", "muslim", "abu_dawud", "tirmidhi", "nasai", "ibn_majah"]
+        result = build_hadith_filter(collections)
+        should_block = result["must"][0]
+        values = {c["match"]["value"] for c in should_block["should"]}
+        assert values == set(collections)
+
+    def test_uses_collection_key_not_scholar(self):
+        result = build_hadith_filter(["bukhari"])
+        cond = result["must"][0]
+        assert cond["key"] == "collection"
 
 
 # ── normalize ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Wires a separate Qdrant `hadith` collection into the pipeline without requiring data to exist yet. The feature is off by default (`hadith_enabled: false`). When enabled with no data, the pipeline catches the 404, logs a warning, and continues with Tafsir chunks only — no errors raised.

## Changes

### `.env.example`
- `QDRANT_HADITH_COLLECTION=hadith` — separate collection name for the hadith corpus

### `scripts/rag_poc.py`
- `build_hadith_filter(hadith_collections)` — OR filter on the `collection` payload field (e.g. `bukhari`, `muslim`); mirrors `build_qdrant_filter` but targets hadith metadata
- `build_runtime()` — adds `hadith_collection` key to returned dict
- `run_pipeline()` — new params: `hadith_enabled`, `hadith_collection`, `hadith_collections`; when enabled, retrieves hadith chunks, normalises `scholar` field from `collection` payload for downstream compatibility, merges with tafsir chunks and re-ranks by score descending before passing to LLM

### `scripts/api.py`
- `QueryOptions`: `hadith_enabled: bool = False`, `hadith_collections: list[str] | None = None`
- Passes hadith params through to `run_pipeline()` with `runtime["hadith_collection"]`
- Adds `hadith_enabled` and `hadith_collections` to response meta and persistence metadata

### `tests/unit/test_rag_poc.py`
- 6 new tests for `build_hadith_filter`: None, empty, single, two-collection, all six Kutub al-Sitta, key name check

## Test results

**Unit tests:** 134/134 passing

**Manual tests (all passed):**
- `hadith_enabled: false` (default) → unchanged pipeline behaviour
- `hadith_enabled: true`, no hadith data → warning logged, valid tafsir response returned
- `hadith_collections: ["bukhari", "muslim"]` → stored correctly in meta
- Tafsir chunks (`maududi`, `ibn_kathir`) returned normally with hadith enabled

**Server log on missing collection (expected):**
```
WARNING — Hadith retrieval skipped (hadith): Unexpected Response: 404 (Not Found)
{"status":{"error":"Not found: Collection `hadith` doesn't exist!"}}
```

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)